### PR TITLE
fix: ministry is none cause crash

### DIFF
--- a/src/pages/Registration/Registration.jsx
+++ b/src/pages/Registration/Registration.jsx
@@ -112,7 +112,7 @@ export default function Registration() {
                 </FormItem>
             </Form>
             {
-                ministry.length !== 0 && (
+                ministry&& ministry.length !== 0 && (
                     <Paragraph>
                         <Title heading={4}>Ministry to be Interviewed</Title>
                         <ul>


### PR DESCRIPTION
### Please tell us what you did
    1. fix bug: clear  Minsitry value cause page empty

### Are there any concerns that may be raised ?
no


### Please add which issue does this PR close below using ("closes #issue_number")
close #2 